### PR TITLE
improve explanation on how to run examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,16 @@ Optional packages
 
 ### Documentation
 The API documentation built with Doxygen can be found [here](https://dshawul.github.io/html/index.html).
-Also READMEs are providied for writing new solvers under `apps/` directory, and for setting up
+Also READMEs are provided for writing new solvers under `apps/` directory, and for setting up
 test cases under `examples/` directory.
 
 ### Testing
 
 A testing script `test.sh` is provided. By default it runs the lid-driven test case
-under `examples/cavity`..
+under `examples/cavity` using the binaries installed with the `make install` command.
 
-To run a test case, execute the script specifying the number of MPI ranks if greater than 1, the
-test case name.
+To run a test case, set the binary folder of the installation directory in `test.sh` and execute the script
+specifying the number of MPI ranks, if greater than, 1 and the test case name.
 
     ./test.sh -n 2 -c examples/atmo/advection-leveque/bubble
 

--- a/test.sh
+++ b/test.sh
@@ -45,14 +45,14 @@ run() {
     #generate grid
     format=$(grep -v "^#" ./controls | grep write_format | awk '{print $2}')
     if [ "$format" == "TEXT" ]; then
-        ${bin_path}mesh $1 -o grid_0.txt
+        ${bin_path}/mesh $1 -o grid_0.txt
     else
-        ${bin_path}mesh $1 -o grid_0.bin
+        ${bin_path}/mesh $1 -o grid_0.bin
     fi
 
     #solve
     solver=$(grep -v "^#" ./controls | grep solver | awk '{print $2}')
-    mpirun -n $2 -bind-to numa ${bin_path}${solver} ./controls | tee log.txt
+    mpirun -n $2 -bind-to numa ${bin_path}/${solver} ./controls | tee log.txt
 }
 
 #prepare directory
@@ -80,7 +80,7 @@ if [ $nprocs -gt 1 ]; then
     t=1
     file=(./grid0/$field$t.*)
     while [ -f "$file" ]; do
-        mpirun -n $nprocs ${bin_path}prepare ./controls -merge -start $t
+        mpirun -n $nprocs ${bin_path}/prepare ./controls -merge -start $t
         t=$((t+1))
         file=(./grid0/$field$t.*)
     done
@@ -90,7 +90,7 @@ fi
 t=0
 file=(./$field$t.*)
 while [ -f "$file" ]; do
-    mpirun -n 1 ${bin_path}prepare ./controls -vtk -start $t
+    mpirun -n 1 ${bin_path}/prepare ./controls -vtk -start $t
     t=$((t+1))
     file=(./$field$t.*)
 done


### PR DESCRIPTION
The commands shown in the README fail to run without modifications, and the `test.sh` script does not give any helpful output on the failures.
This rephrasing helps identify what needs to be modified to make it work.
Having some error checking in the `test.sh` script would also be helpful.